### PR TITLE
商品削除機能の実装

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,5 +1,5 @@
 class ItemsController < ApplicationController
-  before_action :authenticate_user!, only: [:new, :create, :edit, :update]
+  before_action :authenticate_user!, except: [:index, :show]
   before_action :set_item, only: [:show, :edit, :update, :destroy]  # インスタンスの生成
   before_action :user_match, only: [:edit, :update, :destroy]
 

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,7 +1,7 @@
 class ItemsController < ApplicationController
   before_action :authenticate_user!, only: [:new, :create, :edit, :update]
-  before_action :set_item, only: [:show, :edit, :update]  # インスタンスの生成
-  before_action :user_match, only: [:edit, :update]
+  before_action :set_item, only: [:show, :edit, :update, :destroy]  # インスタンスの生成
+  before_action :user_match, only: [:edit, :update, :destroy]
 
   def index
     @items = Item.all.order(id: "DESC")
@@ -34,6 +34,11 @@ class ItemsController < ApplicationController
     else
       render action: :edit
     end
+  end
+
+  def destroy
+    @item.destroy
+    redirect_to root_path
   end
 
   private

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -21,7 +21,7 @@ class ItemsController < ApplicationController
   end
 
   def show
-    
+
   end
   
   def edit

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -27,7 +27,7 @@
      <% if current_user.id == @item.user_id%>
       <%= link_to "商品の編集", edit_item_path(@item.id), method: :get, class: "item-red-btn" %>
       <p class="or-text">or</p>
-      <%= link_to "削除", "#", method: :delete, class:"item-destroy" %>
+      <%= link_to "削除", item_path(@item.id), method: :delete, class:"item-destroy" %>
     <%else%>
       <%# 商品が売れていない場合はこちらを表示しましょう %>
       <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
   devise_for :users
   root to: "items#index"
-  resources :items, only: [:index, :new, :create, :show, :edit, :update]
+  resources :items, only: [:index, :new, :create, :show, :edit, :update, :destroy]
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
   devise_for :users
   root to: "items#index"
-  resources :items, only: [:index, :new, :create, :show, :edit, :update, :destroy]
+  resources :items
 end


### PR DESCRIPTION
# what
- destroyアクションは出品者のユーザのみ可能

- ログイン状態の出品者のみ、詳細ページの削除ボタンを押すと、出品した商品を削除できる動画　
　【https://gyazo.com/0318b3ca723a8522ff893ca9d29e1da0】

# why
- 商品削除機能の実装のため